### PR TITLE
Expose build method to make it possible to be integrated

### DIFF
--- a/pynt/__init__.py
+++ b/pynt/__init__.py
@@ -5,9 +5,9 @@ Lightweight Python Build Tool
 __version__ = "0.8.1"
 __license__ = "MIT License"
 __contact__ = "http://rags.github.com/pynt/"
-from ._pynt import task, main
+from ._pynt import task, main, build
 import pkgutil
 
 __path__ = pkgutil.extend_path(__path__,__name__)
 
-__all__ = ["task",  "main"]
+__all__ = ["task",  "main", "build"]


### PR DESCRIPTION
Currently it is impossible to integrate pynt to other projects. Expose build method will help to resolve this.