### PR TITLE
added error task example as there was none present

### DIFF
--- a/example.py
+++ b/example.py
@@ -34,6 +34,11 @@ def copy_file(src, dest):
 def echo(*args,**kwargs):
     print(args)
     print(kwargs)
+
+@task()
+def error_task():
+    print "this should fail with an error"
+    raise IOError
     
 # Default task (if specified) is run when no task is specified in the command line
 # make sure you define the variable __DEFAULT__ after the task is defined


### PR DESCRIPTION
I was looking for an example of a task that throws an error that can be picked up by a build server as opposed to saying it completed.