### PR TITLE
@task(hide=True) support

### DIFF
--- a/pynt/_pynt.py
+++ b/pynt/_pynt.py
@@ -237,6 +237,7 @@ class Task(object):
         self.doc = inspect.getdoc(func) or ''
         self.dependencies = dependencies
         self.ignored =  bool(options.get('ignore', False))
+        self.show = not bool(options.get('hide', False))
         
     def __call__(self,*args,**kwargs):
         self.func.__call__(*args,**kwargs)
@@ -256,7 +257,7 @@ def _get_tasks(module):
     """
     # Get all functions that are marked as task and pull out the task object
     # from each (name,value) pair.
-    return set(member[1] for member in inspect.getmembers(module,Task.is_task))
+    return set(member[1] for member in inspect.getmembers(module,Task.is_task) if member[1].show)
     
 def _get_max_name_length(module):
     """


### PR DESCRIPTION
If `@task(hide=True)` is set, the given task won't appear in the auto-generated docs. It's useful if you want to hide sub-tasks and you only want to see the main tasks in the generated list.