### PR TITLE
Added ability to enforce strict task name argument matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ def echo(*args,**kwargs):
     print args
     print kwargs
     
+# You can optionally enforce strict task name matching; if left out, the first
+# few characters of the task name are enough to execute the task, as long as
+# the partial name is unambigious
+# __TASK_NAME_RESOLVER__ = 'strict'
+
 # Default task (if specified) is run when no task is specified in the command line
 # make sure you define the variable __DEFAULT__ after the task is defined
 # A good convention is to define it at the end of the module
@@ -151,7 +156,9 @@ Starting server at localhost:80
 [ example.py - Completed task "start_server" ]
 ```
 
-The first few characters of the task name is enough to execute the task, as long as the partial name is unambigious. You can specify multiple tasks to run in the commandline. Again the dependencies are taken taken care of.
+The first few characters of the task name are enough to execute the task, as long as the partial name is unambigious. This behaviour can be disabled by adding the statement `__TASK_NAME_RESOLVER__ = 'strict'` to your build file.
+
+You can specify multiple tasks to run in the commandline. Again the dependencies are taken taken care of.
 
 ```bash
 $ pynt cle ht cl

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,11 @@ still be run with ``pynt _private_task_name``
         print args
         print kwargs
 
+    # You can optionally enforce strict task name matching; if left out, the first
+    # few characters of the task name are enough to execute the task, as long as
+    # the partial name is unambigious
+    # __TASK_NAME_RESOLVER__ = 'strict'
+
     # Default task (if specified) is run when no task is specified in the command line
     # make sure you define the variable __DEFAULT__ after the task is defined
     # A good convention is to define it at the end of the module
@@ -160,10 +165,13 @@ ignored).
     Starting server at localhost:80
     [ example.py - Completed task "start_server" ]
 
-The first few characters of the task name is enough to execute the task,
-as long as the partial name is unambigious. You can specify multiple
-tasks to run in the commandline. Again the dependencies are taken taken
-care of.
+The first few characters of the task name are enough to execute the task,
+as long as the partial name is unambigious. This behaviour can be disabled
+by adding the statement `__TASK_NAME_RESOLVER__ = 'strict'` to your build
+file.
+
+You can specify multiple tasks to run in the commandline. Again the dependencies
+are taken taken care of.
 
 ::
 

--- a/pynt/__init__.py
+++ b/pynt/__init__.py
@@ -2,7 +2,7 @@
 Lightweight Python Build Tool
 """
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 __license__ = "MIT License"
 __contact__ = "http://rags.github.com/pynt/"
 from ._pynt import task, main

--- a/pynt/tests/build_scripts/build_with_strict_task_names.py
+++ b/pynt/tests/build_scripts/build_with_strict_task_names.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+
+from pynt import task
+
+tasks_run = []
+    
+@task()
+def clean(directory='/tmp'):
+    tasks_run.append('clean[%s]' % directory)
+
+    
+@task(clean)
+def html():
+    tasks_run.append('html')
+
+
+@task()
+def tests(*test_names):
+    tasks_run.append('tests[%s]' % ','.join(test_names))
+
+
+@task(clean)
+def copy_file(from_, to, fail_on_error='True'):
+    tasks_run.append('copy_file[%s,%s,%s]' % (from_, to, fail_on_error))
+
+
+@task(clean)
+def start_server(port='80', debug='True'):
+    tasks_run.append('start_server[%s,%s]' % (port, debug))
+
+@task(ignore=True)
+def ignored(file, contents):
+    tasks_run.append('append_to_file[%s,%s]' % (file, contents))
+
+@task(clean, ignored)
+def append_to_file(file, contents):
+    tasks_run.append('append_to_file[%s,%s]' % (file, contents))
+
+    
+@task(ignored)
+def echo(*args,**kwargs):
+    args_str = []
+    if args:
+        args_str.append(','.join(args))
+    if kwargs:
+        args_str.append(','.join("%s=%s" %  (kw, kwargs[kw]) for kw in sorted(kwargs)))
+
+    tasks_run.append('echo[%s]' % ','.join(args_str))
+
+__TASK_NAME_RESOLVER__ = 'strict'

--- a/pynt/tests/test_pynt.py
+++ b/pynt/tests/test_pynt.py
@@ -203,6 +203,24 @@ class TestPartialTaskNames:
                 'Conflicting matches copy_file, clean for task c' in str(exc.value))
 
 
+class TestStrictTaskNames:
+
+    def setup_method(self):
+        from .build_scripts import build_with_strict_task_names
+        self._mod = build_with_strict_task_names
+
+    def test_task_resolver_statement(self):
+        assert False == _pynt._match_task_names_heuristically(self._mod)
+        
+    def test_exception_on_partial_task_name(self):
+        with pytest.raises(Exception) as exc:
+            build(self._mod, ["c"])
+        assert 'Invalid task \'c\'' in str(exc.value)
+
+    def test_with_valid_task_name_and_dependencies(self):
+        mod = build(self._mod, ["html"])
+        assert ['clean[/tmp]','html'] ==  mod.tasks_run
+
 
 class TestDefaultTask:
         def test_simple_default_task(self):


### PR DESCRIPTION
Hi,

Sometimes the task name matching feature can be a dangerous thing and one might only want to allow exactly matching task names as arguments.

This merge request introduces the ability to add the statement `__TASK_NAME_RESOLVER__ = 'strict'` to the build file to tell pynt to only accept fully matching task names.

Unit tests have been updated.

Thanks,
Torben
